### PR TITLE
Update implementation to latest xtensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ poles, residues, cf, fit, rms = m.vectfit(f, s, init_poles, weight)
 
   It is convenient to install all the libraries through conda package manager:
 
-  `conda install -c conda-forge xtensor-blas xtensor-python`
+  `conda install -c conda-forge xtensor-blas=0.15 xtensor-python`
 
 ### Build and install
 

--- a/src/vectfit.cpp
+++ b/src/vectfit.cpp
@@ -327,7 +327,7 @@ vectfit(xt::pyarray<double> &f,
     }
 
     auto results = xt::linalg::lstsq(AA, bb);
-    auto x = xt::view(std::get<0>(results), xt::all(), 1);
+    auto x = std::get<0>(results);
     x *= Escale;
     auto C = xt::xarray<double>(xt::view(x, xt::range(0, x.size() - 1)));
     auto D = x(x.size() - 1);
@@ -388,7 +388,7 @@ vectfit(xt::pyarray<double> &f,
       }
 
       auto results = xt::linalg::lstsq(AA, bb);
-      auto C = xt::view(std::get<0>(results), xt::all(), 1);
+      auto C = std::get<0>(results);
       C *= Escale;
     }
 
@@ -488,7 +488,7 @@ vectfit(xt::pyarray<double> &f,
       }
 
       auto results = xt::linalg::lstsq(A, b);
-      auto x = xt::view(std::get<0>(results), xt::all(), 1);
+      auto x = std::get<0>(results);
       x *= Escale;
 
       xt::view(Cr, n) = xt::view(x, xt::range(0, N));


### PR DESCRIPTION
This implementation depends on xtensor and xtensor-blas, but several updates of those packages are non-backward compatible, prevents the installation of vectfit. This PR updates to the latest xtensor.