### PR TITLE
Fix broken pip install

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[build-system]
+requires = ["setuptools", "wheel", "numpy", "pybind11>=2.0.1"]

--- a/setup.py
+++ b/setup.py
@@ -1,40 +1,15 @@
 from setuptools import setup, Extension
 from setuptools.command.build_ext import build_ext
+import setuptools
 import sys
 import os
-import setuptools
+import tempfile
+
+import numpy as np
+import pybind11
+
 
 __version__ = '0.1'
-
-
-class get_pybind_include(object):
-    """Helper class to determine the pybind11 include path
-
-    The purpose of this class is to postpone importing pybind11
-    until it is actually installed, so that the ``get_include()``
-    method can be invoked. """
-
-    def __init__(self, user=False):
-        self.user = user
-
-    def __str__(self):
-        import pybind11
-        return pybind11.get_include(self.user)
-
-
-class get_numpy_include(object):
-    """Helper class to determine the numpy include path
-
-    The purpose of this class is to postpone importing numpy
-    until it is actually installed, so that the ``get_include()``
-    method can be invoked. """
-
-    def __init__(self):
-        pass
-
-    def __str__(self):
-        import numpy as np
-        return np.get_include()
 
 
 ext_modules = [
@@ -43,9 +18,9 @@ ext_modules = [
         ['src/vectfit.cpp'],
         include_dirs=[
             # Path to pybind11 headers
-            get_pybind_include(),
-            get_pybind_include(user=True),
-            get_numpy_include(),
+            pybind11.get_include(),
+            pybind11.get_include(True),
+            np.get_include(),
             os.path.join(sys.prefix, 'include'),
             os.path.join(sys.prefix, 'Library', 'include')
         ],
@@ -59,7 +34,6 @@ def has_flag(compiler, flagname):
     """Return a boolean indicating whether a flag name is supported on
     the specified compiler.
     """
-    import tempfile
     with tempfile.NamedTemporaryFile('w', suffix='.cpp') as f:
         f.write('int main (int argc, char **argv) { return 0; }')
         try:
@@ -106,7 +80,7 @@ class BuildExt(build_ext):
 
 with open('README.md') as f:
     long_description = f.read()
-    
+
 setup(
     name='vectfit',
     version=__version__,
@@ -116,7 +90,7 @@ setup(
     description= 'Fast Relaxed Vector Fitting Implementation in C++',
     long_description=long_description,
     ext_modules=ext_modules,
-    install_requires=['pybind11>=2.0.1', 'numpy'],
+    install_requires=['numpy'],
     cmdclass={'build_ext': BuildExt},
     zip_safe=False,
 )


### PR DESCRIPTION
The [latest version of pip changed the behavior](https://pip.pypa.io/en/stable/news/#v23-1) of `pip install` for projects that don't have a pyprojec.toml file. This results in a build error when running `pip install` on vectfit as evidenced by [recent CI builds of OpenMC that fail](https://github.com/openmc-dev/openmc/actions/runs/4709602358/jobs/8352766615?pr=2471). This PR adds a pyproject.toml file that lists the proper build dependencies (pybind11 and numpy) so that installing with `pip install` should work (provided xtensor, etc. are installed properly and headers can be found).